### PR TITLE
Remove fs module dependency so module can be used on browsers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,6 @@ var sources = {
 var defaultConfig = {
 	cacheLifetime: 24 * 60 * 60 * 1000,
 	source: 'static',
-	staticPath: path.join(__dirname, '..', 'node_modules', 'business-calendar', 'data'),
 	httpBase: 'https://pagarme.github.io/business-calendar/data'
 };
 

--- a/lib/static-source.js
+++ b/lib/static-source.js
@@ -1,9 +1,7 @@
-var fs = require('fs');
-var path = require('path');
 var Promise = require('bluebird-ff');
-var readFileAsync = Promise.promisify(fs.readFile);
+var calendar = require('business-calendar');
 
-exports.load = function(country, year, config) {
-	return readFileAsync(path.join(config.staticPath, country, year + '.json')).then(JSON.parse);
+exports.load = function(country, year) {
+    return Promise.resolve(calendar.getCalendar(country, year));
 };
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/pagarme/business-moment#readme",
   "dependencies": {
     "bluebird-ff": "^1.0.2",
-    "business-calendar": "^1.0.0",
+    "business-calendar": "^1.1.0",
     "moment": "^2.11.2",
     "prequest": "^1.0.0",
     "ramda": "^0.19.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-moment",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Business calendar momentjs plugin",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
@greenboxal CI is not passing because the business-calendar module must be published to version 1.1.0.

closes pagarme/business-moment#2
