### PR TITLE
set pagarme/moment as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "bluebird-ff": "^1.0.2",
     "business-calendar": "^1.3.3",
-    "moment": "2.13.0",
+    "moment": "https://github.com/pagarme/moment/archive/0.0.2.tar.gz",
     "prequest": "^1.0.0",
     "ramda": "^0.19.1"
   },

--- a/test/query.js
+++ b/test/query.js
@@ -9,25 +9,25 @@ describe('Query', function() {
 
 	describe('isBusinessDay', function() {
 		it('should return false on saturday', function() {
-			return expect(bm.isBusinessDay('brazil', new Date(2016, 1, 6))).to.eventually.eql(false);
+			return expect(bm.isBusinessDay('brazil', new Date(2016, 1, 6, 10))).to.eventually.eql(false);
 		});
 
 		it('should return false on sunday', function() {
-			return expect(bm.isBusinessDay('brazil', new Date(2016, 1, 7))).to.eventually.eql(false);
+			return expect(bm.isBusinessDay('brazil', new Date(2016, 1, 7, 10))).to.eventually.eql(false);
 		});
 
 		it('should return false on holidays', function() {
-			return expect(bm.isBusinessDay('brazil', new Date(2016, 1, 8))).to.eventually.eql(false);
+			return expect(bm.isBusinessDay('brazil', new Date(2016, 1, 8, 10))).to.eventually.eql(false);
 		});
 
 		it('should return false on days with partial financial operation', function() {
-			return expect(bm.isBusinessDay('brazil', new Date(2016, 11, 24))).to.eventually.eql(false);
+			return expect(bm.isBusinessDay('brazil', new Date(2016, 11, 24, 10))).to.eventually.eql(false);
 		});
 	});
 
 	describe('nextBusinessDay', function() {
 		it('should return the correct day', function() {
-			return expect(bm.nextBusinessDay('brazil', new Date(2016, 1, 5))).to.eventually.eql(new Date(2016, 1, 10));
+			return expect(bm.nextBusinessDay('brazil', new Date(2016, 1, 5, 10))).to.eventually.eql(new Date(2016, 1, 10, 10));
 		});
 	});
 });


### PR DESCRIPTION
Given that moment doesn't consider time zones. It changes the moment dependency to pagarme's moment version that uses _moment-timezone_ setting `America/Sao_Paulo` as the default timezone. Doing this the tests broke because considering the timezone the date objects were instantiated wrongly. This commit fixes that problem setting hours to these date objects.