### PR TITLE
Atualiza versão do moment para a 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-moment",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Business calendar momentjs plugin",
   "main": "lib/index.js",
   "scripts": {
@@ -26,7 +26,7 @@
   "dependencies": {
     "bluebird-ff": "^1.0.2",
     "business-calendar": "^1.3.3",
-    "moment": "https://github.com/pagarme/moment/archive/0.0.4.tar.gz",
+    "moment": "https://github.com/pagarme/moment/archive/0.0.5.tar.gz",
     "prequest": "^1.0.0",
     "ramda": "^0.19.1"
   },


### PR DESCRIPTION
# Descrição

Esse PR atualiza a versão do `pagarme/moment` para a `0.0.5` que consequentemente atualiza o `moment-timezone` da `0.5.23` para `0.5.26` que corrige as definições de horário de verão de 2019 para não existir, e com isso corrigimos os problemas de datas quando usamos `moment`.

`pagarme/moment`: https://github.com/pagarme/moment/pull/9